### PR TITLE
Updated JS redirect from .github.com to .github.io

### DIFF
--- a/base.js
+++ b/base.js
@@ -6,9 +6,8 @@
 	}
 
 	function getSourcePath() {
-		// If accessed via addyosmani.github.com/todomvc/, strip the project
-		// path.
-		if (location.hostname.indexOf('github.com') > 0) {
+		// If accessed via addyosmani.github.io/todomvc/, strip the project path.
+		if (location.hostname.indexOf('github.io') > 0) {
 			return location.pathname.replace(/todomvc\//, '');
 		}
 		return location.pathname;
@@ -29,9 +28,8 @@
 	}
 
 	function redirect() {
-		if (location.hostname === 'addyosmani.github.com') {
-			location.href = location.href.replace('addyosmani.github.com/todomvc',
-												  'todomvc.com');
+		if (location.hostname === 'addyosmani.github.io') {
+			location.href = location.href.replace('addyosmani.github.io/todomvc', 'todomvc.com');
 		}
 	}
 

--- a/component.json
+++ b/component.json
@@ -1,4 +1,4 @@
 {
   "name": "todomvc-common",
-  "version": "0.1.2"
+  "version": "0.1.4"
 }


### PR DESCRIPTION
Since Github will be redirecting ___.github.com URLs to ___.github.io, I don't think anyone could load `addyosmani.github.com` and have our JS execute without having already been redirected to `addyosmani.github.io`. I switched the version as well, and created a tag for `v0.1.4`, though I don't know if this PR will include my tag.
