### PR TITLE
add api adapter / backend link behavior.

### DIFF
--- a/base.js
+++ b/base.js
@@ -171,25 +171,42 @@
 			framework = document.querySelector('[data-framework]').dataset.framework;
 		}
 
+		this.template = template;
 
-		if (template && learnJSON[framework]) {
+		if (learnJSON.backend) {
+			this.frameworkJSON = learnJSON.backend;
+			this.append({
+				backend: true
+			});
+		} else if (learnJSON[framework]) {
 			this.frameworkJSON = learnJSON[framework];
-			this.template = template;
-
 			this.append();
 		}
 	}
 
-	Learn.prototype.append = function () {
+	Learn.prototype.append = function (opts) {
 		var aside = document.createElement('aside');
 		aside.innerHTML = _.template(this.template, this.frameworkJSON);
 		aside.className = 'learn';
 
-		// Localize demo links
-		var demoLinks = aside.querySelectorAll('.demo-link');
-		Array.prototype.forEach.call(demoLinks, function (demoLink) {
-			demoLink.setAttribute('href', findRoot() + demoLink.getAttribute('href'));
-		});
+		if (opts && opts.backend) {
+			// Remove demo link
+			var sourceLinks = aside.querySelector('.source-links');
+			var heading = sourceLinks.firstElementChild;
+			var sourceLink = sourceLinks.lastElementChild;
+			// Correct link path
+			var href = sourceLink.getAttribute('href');
+			sourceLink.setAttribute('href', href.substr(href.lastIndexOf('http')));
+			sourceLinks.innerHTML = heading.outerHTML + sourceLink.outerHTML;
+		} else {
+			// Localize demo links
+			var demoLinks = aside.querySelectorAll('.demo-link');
+			Array.prototype.forEach.call(demoLinks, function (demoLink) {
+				if (demoLink.getAttribute('href').substr(0, 4) !== 'http') {
+					demoLink.setAttribute('href', findRoot() + demoLink.getAttribute('href'));
+				}
+			});
+		}
 
 		document.body.className = (document.body.className + ' learn-bar').trim();
 		document.body.insertAdjacentHTML('afterBegin', aside.outerHTML);


### PR DESCRIPTION
Re: https://github.com/tastejs/todomvc/pull/1050

Modifies link display and behavior after changes from the above PR are merged. The PR also has logic changes to the template from learn.json, in a backward compatible way: https://github.com/tastejs/todomvc/pull/1050/files#diff-719bcdeda5b5e8046f18065efe042e27R2273

Version bump after this would be 0.3.0? If 0.2.1, I'll have to change https://github.com/tastejs/todomvc/pull/1050/files#diff-75be9f28ab6ec31d1dd17ce7c7600e47R6
